### PR TITLE
Fix missing templates directory after pip installing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft templates

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-graft templates
+graft debug_toolbar_pycassa

--- a/debug_toolbar_pycassa/pycassa_panel.py
+++ b/debug_toolbar_pycassa/pycassa_panel.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from debug_toolbar.panels import Panel
 
-import pycassa_tracker as tracker
+from . import pycassa_tracker as tracker
 
 SUBTITLE_TEMPLATE = u"""
 {% for o, n, t in operations %}
@@ -31,24 +31,24 @@ class PycassaDebugPanel(Panel):
     def nav_subtitle(self):
         fun = lambda x, y: (x, len(y), '%.2f' % sum(z['time'] for z in y))
         ctx = {'operations': [], 'count': 0, 'time': 0}
-        
+
         if tracker.queries:
             ctx['operations'].append(fun('read', tracker.queries))
             ctx['count'] += len(tracker.queries)
             ctx['time'] += sum(x['time'] for x in tracker.queries)
-        
+
         if tracker.inserts:
             ctx['operations'].append(fun('insert', tracker.inserts))
             ctx['count'] += len(tracker.inserts)
             ctx['time'] += sum(x['time'] for x in tracker.inserts)
-        
+
         if tracker.removes:
             ctx['operations'].append(fun('remove', tracker.removes))
             ctx['count'] += len(tracker.removes)
             ctx['time'] += sum(x['time'] for x in tracker.removes)
-        
+
         ctx['time'] = '%.2f' % ctx['time']
-        
+
         return mark_safe(Template(SUBTITLE_TEMPLATE).render(Context(ctx)))
 
     def title(self):

--- a/debug_toolbar_pycassa/pycassa_tracker.py
+++ b/debug_toolbar_pycassa/pycassa_tracker.py
@@ -2,7 +2,8 @@ import functools
 import time
 import inspect
 import os
-import SocketServer
+
+import six
 
 import pycassa
 
@@ -263,7 +264,7 @@ def _tidy_stacktrace(stack):
     """
     django_path = os.path.realpath(os.path.dirname(django.__file__))
     django_path = os.path.normpath(os.path.join(django_path, '..'))
-    socketserver_path = os.path.realpath(os.path.dirname(SocketServer.__file__))
+    socketserver_path = os.path.realpath(os.path.dirname(six.moves.socketserver.__file__))
     pycassa_path = os.path.realpath(os.path.dirname(pycassa.__file__))
 
     trace = []


### PR DESCRIPTION
`pip install git+https://github.com/pista329/django-debug-toolbar-pycassa`
results in a missing 'templates' directory